### PR TITLE
Updated broken Arlington Finances link in sidebar nav

### DIFF
--- a/docs/data/navigation.yml
+++ b/docs/data/navigation.yml
@@ -29,6 +29,6 @@ main:
       - title: Arlington GIS Maps
         url: https://www.arlingtonma.gov/departments/information-technology/geographic-information-system-gis
       - title: Arlington Finances
-        url: https://www.arlingtonma.gov/town-governance/financial-budget-information
+        url: https://www.arlingtonma.gov/departments/finance/financial-budget-information
       - title: Arlington Visual Budget
         url: http://arlingtonvisualbudget.org/


### PR DESCRIPTION
The `Arlington Finances` link was broken in the sidebar navigation, but I believe this is the correct updated URL. 